### PR TITLE
Fix timer interval comment mismatch

### DIFF
--- a/ArbeitInventur/Formes/Login.cs
+++ b/ArbeitInventur/Formes/Login.cs
@@ -22,7 +22,7 @@ namespace ArbeitInventur
             labelError.Text = "";
 
             errorTimer = new Timer();
-            errorTimer.Interval = 1500; // 2 Sekunden (2000 Millisekunden)
+            errorTimer.Interval = 2000; // 2 Sekunden (2000 Millisekunden)
             errorTimer.Tick += ErrorTimer_Tick;
 
             this.KeyPreview = true;


### PR DESCRIPTION
## Summary
- update `errorTimer.Interval` to match comment in `Login.cs`

## Testing
- `dotnet build ArbeitInventur.sln` *(fails: command not found)*
- `msbuild ArbeitInventur.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5cfa0604832880133865c3bf57ca