### PR TITLE
Fix folder uploader log messages

### DIFF
--- a/ArbeitInventur/UC_Exocad.cs
+++ b/ArbeitInventur/UC_Exocad.cs
@@ -118,7 +118,7 @@ namespace ArbeitInventur
                 _folderUploader.StopWatching();
                 _folderUploader.Dispose();
                 _folderUploader = null;
-                AddToListBox("Überwachung von Ordner-Upload gestartet.");
+                AddToListBox("Überwachung von Ordner-Upload gestoppt.");
             }
             else if (chk_FolderUploader.Checked == true)
             {
@@ -133,7 +133,7 @@ namespace ArbeitInventur
                 _folderUploader = new FolderWatcherAndUploader(localFolder, serverFolder, _logHandler);
                 _folderUploader.FolderUploaded += OnFolderUploaded;
                 _folderUploader.StartWatching();
-                AddToListBox("Überwachung von Ordner-Upload gestoppt.");
+                AddToListBox("Überwachung von Ordner-Upload gestartet.");
             }
         }
 


### PR DESCRIPTION
## Summary
- correct logging messages in `InitializeFolderUploader`

## Testing
- `msbuild ArbeitInventur.sln` *(fails: command not found)*
- `dotnet build ArbeitInventur.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5cf1b1f0832883daf484147c0242